### PR TITLE
Only keep the version number. If its invalid, set it as unknown.

### DIFF
--- a/usage-stats-handler/push.sh
+++ b/usage-stats-handler/push.sh
@@ -1,6 +1,6 @@
 #/bin/sh
 IMAGENAME=grafana/usage-stats-handler
-VERSION=v11
+VERSION=v12
 
 docker build -t $IMAGENAME:latest -t $IMAGENAME:$VERSION --no-cache=true .
 


### PR DESCRIPTION
Should be easier to reason about and avoids passing sketchy versions to the graphite lib. 

I'm not sure if this will mean the process will be running. I haven't tested writing to a graphite server yet. 