### PR TITLE
set latest to v12-2

### DIFF
--- a/usage-stats-handler/push.sh
+++ b/usage-stats-handler/push.sh
@@ -1,8 +1,8 @@
 #/bin/sh
 IMAGENAME=grafana/usage-stats-handler
-VERSION=v12
+VERSION=v12-2
 
-docker build -t $IMAGENAME:latest -t $IMAGENAME:$VERSION --no-cache=true .
+DOCKER_DEFAULT_PLATFORM="linux/amd64" docker build -t $IMAGENAME:latest -t $IMAGENAME:$VERSION --no-cache=true .
 
 docker push $IMAGENAME:latest
 docker push $IMAGENAME:$VERSION


### PR DESCRIPTION
I built v12 without the default platform param which means v12 is an arm build. 

To fix that I built v12-2 instead of pushing over v12 since the k8s nodes might have the v12 image cached. 